### PR TITLE
Bump Eclipse Temurin Java JDK from 21.0.8+9-LTS to 25+36-LTS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ We use the [Eclipse Temurin](https://adoptium.net/temurin/) Java JDK, but other 
 Omega Codex works with following versions, but other versions may also work:
 
 - Eclipse Temurin:
-  - `21.0.8+9-LTS`
+  - `25+36-LTS`
 - Apache Maven:
   - `3.9.11`
 


### PR DESCRIPTION
Fixes #180