### PR TITLE
Use "increase-if-necessary" strategy for Python dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,7 @@ updates:
     directory: "/python-tools"
     schedule:
       interval: "weekly"
+    versioning-strategy: increase-if-necessary
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Fixes #247