### PR TITLE
Increase Dependabot pull request limit from 10 to 50.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50
     groups:
       org-mockito:
         patterns:
@@ -36,4 +36,4 @@ updates:
     versioning-strategy: increase
     allow:
       - dependency-type: "all"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50


### PR DESCRIPTION
Fixes #468