### PR TITLE
Use BOM to manage org.slf4j dependency versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,18 @@ limitations under the License.
         </profile>
     </profiles>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-bom</artifactId>
+                <version>2.0.17</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- graphical interface -->
         <dependency>
@@ -94,12 +106,10 @@ limitations under the License.
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.17</version>
         </dependency>
 
         <!-- testing -->


### PR DESCRIPTION
Fixes #492