### PR TITLE
Use BOM to manage org.mockito dependency versions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,6 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 50
     groups:
-      org-mockito:
-        patterns:
-          - "org.mockito:*"
       testing-plugins:
         patterns:
           - "org.apache.maven.plugins:maven-failsafe-plugin"

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,13 @@ limitations under the License.
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>5.23.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -122,13 +129,11 @@ limitations under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes #494